### PR TITLE
chore: add MinIO service to docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,22 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
       MONGO_INITDB_DATABASE: ${MONGO_DATABASE}
 
+  minio:
+    image: minio/minio:latest
+    container_name: minio-server
+    ports:
+      - ${MINIO_API_PORT}:9000  # API Port
+      - ${MINIO_WEB_UI_PORT}:9001  # Web UI Port
+    environment:
+      MINIO_ROOT_USER: ${MINIO_USERNAME}
+      MINIO_ROOT_PASSWORD: ${MINIO_PASSWORD}
+    command: server /data --console-address ":${MINIO_WEB_UI_PORT}"
+    networks:
+      - task-nexus-network
+    restart: on-failure
+    volumes:
+      - task-nexus-minio-vol:/data
+
   redis:
     image: redis:7.4.2-alpine
     restart: on-failure
@@ -33,6 +49,8 @@ volumes:
   task-nexus-redis-vol:
     driver: local
   task-nexus-redis-config-vol:
+    driver: local
+  task-nexus-minio-vol:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
 
   minio:
     image: minio/minio:latest
-    container_name: minio-server
     ports:
       - ${MINIO_API_PORT}:9000  # API Port
       - ${MINIO_WEB_UI_PORT}:9001  # Web UI Port


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` file to add a new MinIO service configuration. The most important changes include the addition of the MinIO service under the `services` section and the corresponding volume configuration.

New MinIO service configuration:

* Added MinIO service with the latest image, container name `minio-server`, API and Web UI ports, environment variables for root user and password, command to start the server, network configuration, and restart policy.

Volume configuration for MinIO:

* Added a new volume `task-nexus-minio-vol` with a local driver to support the MinIO service.